### PR TITLE
Add BhopBlocker

### DIFF
--- a/server-plugin/Code/MagicValues.h
+++ b/server-plugin/Code/MagicValues.h
@@ -43,4 +43,18 @@
 
 #define MAX_PLAYERS 66
 
+namespace SystemPriority
+{
+	namespace UserCmdHookListener
+	{
+		size_t const constexpr BadUserCmdBlocker ( 0 );
+		size_t const constexpr SpeedTester ( BadUserCmdBlocker + 1 );
+		size_t const constexpr EyeAnglesTester ( SpeedTester + 1 );
+		size_t const constexpr AutoAttackTester ( EyeAnglesTester + 1 );
+		size_t const constexpr ShotTester ( AutoAttackTester + 1 );
+		size_t const constexpr JumpTester ( ShotTester + 1 );
+		size_t const constexpr BhopBlocker ( JumpTester + 1 );
+	}
+}
+
 #endif // MAGICVALUES_H

--- a/server-plugin/Code/Players/NczPlayerManager.cpp
+++ b/server-plugin/Code/Players/NczPlayerManager.cpp
@@ -317,7 +317,7 @@ bot_takeover
 
 		return;
 	}
-	if( *event_name == 'd' ) // player_disconnect
+	if( *(event_name + 1) == 'i' ) // player_disconnect
 	{
 		if( ev->GetBool ( "bot" ) == false )
 		{

--- a/server-plugin/Code/Systems/BaseSystem.cpp
+++ b/server-plugin/Code/Systems/BaseSystem.cpp
@@ -158,6 +158,7 @@ void BaseSystem::ncz_cmd_fn ( const SourceSdk::CCommand &args )
 					if( args.ArgC () > 2 )
 					{
 						it->m_verbose = atoi ( args.Arg ( 3 ) );
+						Logger::GetInstance ()->Msg<MSG_CMD_REPLY> ( Helpers::format ( "System %s verbose level is now %d", it->GetName (), it->m_verbose ) );
 					}
 					return;
 				}

--- a/server-plugin/Code/Systems/Blockers/BadUserCmdBlocker.cpp
+++ b/server-plugin/Code/Systems/Blockers/BadUserCmdBlocker.cpp
@@ -45,7 +45,7 @@ void BadUserCmdBlocker::Load ()
 		ResetPlayerDataStructByIndex ( it.GetIndex () );
 	}
 
-	RegisterPlayerRunCommandHookListener ( this, 0, SlotStatus::PLAYER_CONNECTED );
+	RegisterPlayerRunCommandHookListener ( this, SystemPriority::UserCmdHookListener::BadUserCmdBlocker, SlotStatus::PLAYER_CONNECTED );
 }
 
 void BadUserCmdBlocker::Unload ()

--- a/server-plugin/Code/Systems/Blockers/BhopBlocker.cpp
+++ b/server-plugin/Code/Systems/Blockers/BhopBlocker.cpp
@@ -1,0 +1,182 @@
+/*
+Copyright 2012 - Le Padellec Sylvain
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "BhopBlocker.h"
+
+#include "Interfaces/InterfacesProxy.h"
+
+#include "Systems/Logger.h"
+
+BhopBlocker::BhopBlocker () :
+	BaseDynamicSystem ( "BhopBlocker" ),
+	playerdatahandler_class (),
+	PlayerRunCommandHookListener (),
+	singleton_class ()
+{
+	METRICS_ADD_TIMER ( "BhopBlocker::PlayerRunCommandCallback", 2.0 );
+}
+
+BhopBlocker::~BhopBlocker ()
+{
+	Unload ();
+}
+
+void BhopBlocker::Init ()
+{
+	InitDataStruct ();
+}
+
+void BhopBlocker::Load ()
+{
+	for( PlayerHandler::const_iterator it ( PlayerHandler::begin () ); it != PlayerHandler::end (); ++it )
+	{
+		ResetPlayerDataStructByIndex ( it.GetIndex () );
+	}
+
+	RegisterPlayerRunCommandHookListener ( this, SystemPriority::UserCmdHookListener::BhopBlocker, SlotStatus::PLAYER_IN_TESTS );
+}
+
+void BhopBlocker::Unload ()
+{
+	RemovePlayerRunCommandHookListener ( this );
+}
+
+bool BhopBlocker::GotJob () const
+{
+	// Create a filter
+	ProcessFilter::HumanAtLeastConnecting const filter_class;
+	// Initiate the iterator at the first match in the filter
+	PlayerHandler::const_iterator it ( &filter_class );
+	// Return if we have job to do or not ...
+	return it != PlayerHandler::end ();
+}
+
+PlayerRunCommandRet BhopBlocker::RT_PlayerRunCommandCallback ( PlayerHandler::const_iterator ph, void* pCmd, void* old_cmd )
+{
+	METRICS_ENTER_SECTION ( "BhopBlocker::PlayerRunCommandCallback" );
+
+
+	/*
+		Prevents jumping right after the end of another jump cmd.
+		If a jump has been blocked, resend it after the delay.
+	*/
+
+	static float const blocking_delay_seconds ( 0.15f );
+
+	float const tick_interval ( SourceSdk::InterfacesProxy::Call_GetTickInterval () );
+	__assume ( tick_interval > 0.0f && tick_interval < 1.0f );
+
+	int const blocking_delay_ticks ( std::floorf ( blocking_delay_seconds / tick_interval ) );
+
+	int const gtick ( Helpers::GetGameTickCount () );
+
+	if( SourceSdk::InterfacesProxy::m_game == SourceSdk::CounterStrikeGlobalOffensive )
+	{
+		SourceSdk::CUserCmd_csgo const * const k_oldcmd ( ( SourceSdk::CUserCmd_csgo const * const )old_cmd );
+		SourceSdk::CUserCmd_csgo * const k_newcmd ( ( SourceSdk::CUserCmd_csgo * const )pCmd );
+
+		int const jmp_changed ( ( k_oldcmd->buttons ^ k_newcmd->buttons ) & IN_JUMP );
+
+		JmpInfo * pdata ( GetPlayerDataStructByIndex ( ph.GetIndex () ) );
+
+		if( jmp_changed )
+		{
+			int const new_jmp ( k_newcmd->buttons & IN_JUMP );
+
+			if( new_jmp != 0 )
+			{
+				// button down				
+
+				if( gtick - pdata->jmp_up_tick < blocking_delay_ticks )
+				{
+					// block it
+
+					k_newcmd->buttons &= ~IN_JUMP;
+					pdata->has_been_blocked = true;
+				}
+				else
+				{
+					pdata->has_been_blocked = false;
+				}
+			}
+			else
+			{
+				// button up
+
+				pdata->jmp_up_tick = gtick;
+			}
+		}
+		else if( pdata->has_been_blocked == true )
+		{
+			if( gtick - pdata->jmp_up_tick >= blocking_delay_ticks )
+			{
+				// resend
+
+				k_newcmd->buttons |= IN_JUMP;
+				pdata->has_been_blocked = false;
+			}
+		}
+	}
+	else
+	{
+		SourceSdk::CUserCmd const * const k_oldcmd ( ( SourceSdk::CUserCmd const * const )old_cmd );
+		SourceSdk::CUserCmd * const k_newcmd ( ( SourceSdk::CUserCmd * const )pCmd );
+
+		int const jmp_changed ( ( k_oldcmd->buttons ^ k_newcmd->buttons ) & IN_JUMP );
+
+		JmpInfo * pdata ( GetPlayerDataStructByIndex ( ph.GetIndex () ) );
+
+		if( jmp_changed )
+		{
+			int const new_jmp ( k_newcmd->buttons & IN_JUMP );
+
+			if( new_jmp != 0 )
+			{
+				// button down				
+
+				if( gtick - pdata->jmp_up_tick < blocking_delay_ticks )
+				{
+					// block it
+
+					k_newcmd->buttons &= ~IN_JUMP;
+					pdata->has_been_blocked = true;
+				}
+				else
+				{
+					pdata->has_been_blocked = false;
+				}
+			}
+			else
+			{
+				// button up
+
+				pdata->jmp_up_tick = gtick;
+			}
+		}
+		else if( pdata->has_been_blocked == true )
+		{
+			if( gtick - pdata->jmp_up_tick >= blocking_delay_ticks )
+			{
+				// resend
+
+				k_newcmd->buttons |= IN_JUMP;
+				pdata->has_been_blocked = false;
+			}
+		}
+	}
+
+	METRICS_LEAVE_SECTION ( "BhopBlocker::PlayerRunCommandCallback" );
+	return PlayerRunCommandRet::CONTINUE;
+}

--- a/server-plugin/Code/Systems/Blockers/BhopBlocker.cpp
+++ b/server-plugin/Code/Systems/Blockers/BhopBlocker.cpp
@@ -15,6 +15,8 @@ limitations under the License.
 
 #include "BhopBlocker.h"
 
+#include <cmath>
+
 #include "Interfaces/InterfacesProxy.h"
 
 #include "Systems/Logger.h"
@@ -128,7 +130,7 @@ PlayerRunCommandRet BhopBlocker::RT_PlayerRunCommandCallback ( PlayerHandler::co
 	float const tick_interval ( SourceSdk::InterfacesProxy::Call_GetTickInterval () );
 	__assume ( tick_interval > 0.0f && tick_interval < 1.0f );
 
-	int const blocking_delay_ticks ( std::floorf ( blocking_delay_seconds / tick_interval ) );
+	int const blocking_delay_ticks ( floorf ( blocking_delay_seconds / tick_interval ) );
 
 	int const gtick ( Helpers::GetGameTickCount () );
 

--- a/server-plugin/Code/Systems/Blockers/BhopBlocker.h
+++ b/server-plugin/Code/Systems/Blockers/BhopBlocker.h
@@ -1,0 +1,66 @@
+/*
+Copyright 2012 - Le Padellec Sylvain
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef BHOPBLOCKER_H
+#define BHOPBLOCKER_H
+
+#include "Systems/BaseSystem.h"
+#include "Players/temp_PlayerDataStruct.h"
+#include "Hooks/PlayerRunCommandHookListener.h"
+#include "Systems/OnTickListener.h"
+#include "Misc/temp_singleton.h"
+
+struct JmpInfo
+{
+	int jmp_up_tick;
+	bool has_been_blocked;
+
+	JmpInfo ()
+	{
+		jmp_up_tick = 0;
+		has_been_blocked = false;
+	};
+	JmpInfo ( const JmpInfo& other )
+	{
+		jmp_up_tick = other.jmp_up_tick;
+		has_been_blocked = other.has_been_blocked;
+	};
+};
+
+class BhopBlocker :
+	public BaseDynamicSystem,
+	public PlayerDataStructHandler<JmpInfo>,
+	public PlayerRunCommandHookListener,
+	public Singleton<BhopBlocker>
+{
+	typedef Singleton<BhopBlocker> singleton_class;
+	typedef PlayerDataStructHandler<JmpInfo> playerdatahandler_class;
+
+public:
+	BhopBlocker ();
+	virtual ~BhopBlocker () final;
+
+	virtual void Init () override final;
+
+	virtual void Load () override final;
+
+	virtual void Unload () override final;
+
+	virtual bool GotJob () const override final;
+
+	virtual PlayerRunCommandRet RT_PlayerRunCommandCallback ( PlayerHandler::const_iterator ph, void * const cmd, void * const old_cmd ) override final;
+};
+
+#endif // BHOPBLOCKER_H

--- a/server-plugin/Code/Systems/Blockers/BhopBlocker.h
+++ b/server-plugin/Code/Systems/Blockers/BhopBlocker.h
@@ -19,22 +19,23 @@ limitations under the License.
 #include "Systems/BaseSystem.h"
 #include "Players/temp_PlayerDataStruct.h"
 #include "Hooks/PlayerRunCommandHookListener.h"
+#include "Hooks/OnGroundHookListener.h"
 #include "Systems/OnTickListener.h"
 #include "Misc/temp_singleton.h"
 
 struct JmpInfo
 {
-	int jmp_up_tick;
+	int on_ground_tick;
 	bool has_been_blocked;
 
 	JmpInfo ()
 	{
-		jmp_up_tick = 0;
+		on_ground_tick = 0;
 		has_been_blocked = false;
 	};
 	JmpInfo ( const JmpInfo& other )
 	{
-		jmp_up_tick = other.jmp_up_tick;
+		on_ground_tick = other.on_ground_tick;
 		has_been_blocked = other.has_been_blocked;
 	};
 };
@@ -43,6 +44,7 @@ class BhopBlocker :
 	public BaseDynamicSystem,
 	public PlayerDataStructHandler<JmpInfo>,
 	public PlayerRunCommandHookListener,
+	public OnGroundHookListener,
 	public Singleton<BhopBlocker>
 {
 	typedef Singleton<BhopBlocker> singleton_class;
@@ -65,6 +67,8 @@ public:
 	virtual bool GotJob () const override final;
 
 	virtual PlayerRunCommandRet RT_PlayerRunCommandCallback ( PlayerHandler::const_iterator ph, void * const cmd, void * const old_cmd ) override final;
+
+	virtual void RT_m_hGroundEntityStateChangedCallback ( PlayerHandler::const_iterator ph, bool const new_isOnGround ) override final;
 };
 
 #endif // BHOPBLOCKER_H

--- a/server-plugin/Code/Systems/Blockers/BhopBlocker.h
+++ b/server-plugin/Code/Systems/Blockers/BhopBlocker.h
@@ -48,6 +48,10 @@ class BhopBlocker :
 	typedef Singleton<BhopBlocker> singleton_class;
 	typedef PlayerDataStructHandler<JmpInfo> playerdatahandler_class;
 
+private:
+	void * convar_sv_enablebunnyhopping;
+	void * convar_sv_autobunnyhopping;
+
 public:
 	BhopBlocker ();
 	virtual ~BhopBlocker () final;

--- a/server-plugin/Code/Systems/Logger.h
+++ b/server-plugin/Code/Systems/Logger.h
@@ -104,8 +104,8 @@ inline bool Logger::IsConsoleConnected () const
 	return m_msg_func != nullptr;
 }
 
-#define SystemVerbose1(x) Logger::GetInstance()->Msg<MSG_VERBOSE1>(x, this->m_verbose)
-#define SystemVerbose2(x) Logger::GetInstance()->Msg<MSG_VERBOSE2>(x, this->m_verbose)
+#define SystemVerbose1(x) if( this->m_verbose >= 1 ) Logger::GetInstance()->Msg<MSG_VERBOSE1>(x, 1)
+#define SystemVerbose2(x) if( this->m_verbose >= 2 ) Logger::GetInstance()->Msg<MSG_VERBOSE2>(x, 2)
 
 #ifdef DEBUG
 #	define DebugMessage(x) Logger::GetInstance()->Msg<MSG_DEBUG>(x, 3)

--- a/server-plugin/Code/Systems/Testers/AutoAttackTester.cpp
+++ b/server-plugin/Code/Systems/Testers/AutoAttackTester.cpp
@@ -45,7 +45,7 @@ void AutoAttackTester::Load ()
 		ResetPlayerDataStructByIndex ( it.GetIndex () );
 	}
 
-	PlayerRunCommandHookListener::RegisterPlayerRunCommandHookListener ( this, 4 );
+	PlayerRunCommandHookListener::RegisterPlayerRunCommandHookListener ( this, SystemPriority::UserCmdHookListener::AutoAttackTester );
 }
 
 void AutoAttackTester::Unload ()

--- a/server-plugin/Code/Systems/Testers/AutoAttackTester.cpp
+++ b/server-plugin/Code/Systems/Testers/AutoAttackTester.cpp
@@ -213,7 +213,7 @@ void AutoAttackTester::FindDetection ( PlayerHandler::const_iterator ph, tb_int*
 
 			float const percent ( ( (float)(c) / (float)(TB_MAX_HISTORY) ) * 100.0f );
 
-			if( percent >= 66.0f )
+			if( percent >= 70.0f )
 			{
 				// construct detection info
 

--- a/server-plugin/Code/Systems/Testers/AutoAttackTester.h
+++ b/server-plugin/Code/Systems/Testers/AutoAttackTester.h
@@ -23,7 +23,7 @@ limitations under the License.
 #include "Misc/temp_singleton.h"
 #include "Misc/temp_Throwback.h"
 
-#define SHORT_TIME (float)(0.09) // sec
+#define SHORT_TIME (float)(0.055) // sec
 
 #define TB_MAX_HISTORY 15
 

--- a/server-plugin/Code/Systems/Testers/EyeAnglesTester.cpp
+++ b/server-plugin/Code/Systems/Testers/EyeAnglesTester.cpp
@@ -47,7 +47,7 @@ void EyeAnglesTester::Load ()
 	}
 
 	SourceSdk::InterfacesProxy::GetGameEventManager ()->AddListener ( this, "round_end", true );
-	PlayerRunCommandHookListener::RegisterPlayerRunCommandHookListener ( this, 2 );
+	PlayerRunCommandHookListener::RegisterPlayerRunCommandHookListener ( this, SystemPriority::UserCmdHookListener::EyeAnglesTester );
 }
 
 void EyeAnglesTester::Unload ()

--- a/server-plugin/Code/Systems/Testers/JumpTester.cpp
+++ b/server-plugin/Code/Systems/Testers/JumpTester.cpp
@@ -53,7 +53,7 @@ void JumpTester::Load ()
 	}
 
 	OnGroundHookListener::RegisterOnGroundHookListener ( this );
-	PlayerRunCommandHookListener::RegisterPlayerRunCommandHookListener ( this, 3 );
+	PlayerRunCommandHookListener::RegisterPlayerRunCommandHookListener ( this, SystemPriority::UserCmdHookListener::JumpTester );
 }
 
 void JumpTester::Unload ()

--- a/server-plugin/Code/Systems/Testers/JumpTester.h
+++ b/server-plugin/Code/Systems/Testers/JumpTester.h
@@ -125,6 +125,10 @@ class JumpTester :
 	typedef Singleton<JumpTester> singleton_class;
 	typedef PlayerDataStructHandler<JumpInfoT> playerdata_class;
 
+private:
+	void * convar_sv_enablebunnyhopping;
+	void * convar_sv_autobunnyhopping;
+
 public:
 	JumpTester ();
 	virtual ~JumpTester () final;

--- a/server-plugin/Code/Systems/Testers/ShotTester.cpp
+++ b/server-plugin/Code/Systems/Testers/ShotTester.cpp
@@ -50,7 +50,7 @@ void ShotTester::Load ()
 		ResetPlayerDataStructByIndex ( it.GetIndex () );
 	}
 
-	PlayerRunCommandHookListener::RegisterPlayerRunCommandHookListener ( this, 4 );
+	PlayerRunCommandHookListener::RegisterPlayerRunCommandHookListener ( this, SystemPriority::UserCmdHookListener::ShotTester );
 }
 
 void ShotTester::Unload ()

--- a/server-plugin/Code/Systems/Testers/SpeedTester.cpp
+++ b/server-plugin/Code/Systems/Testers/SpeedTester.cpp
@@ -43,7 +43,7 @@ void SpeedTester::Load ()
 	}
 
 	OnTickListener::RegisterOnTickListener ( this );
-	PlayerRunCommandHookListener::RegisterPlayerRunCommandHookListener ( this, 1 );
+	PlayerRunCommandHookListener::RegisterPlayerRunCommandHookListener ( this, SystemPriority::UserCmdHookListener::SpeedTester );
 }
 
 void SpeedTester::Unload ()

--- a/server-plugin/Code/plugin.cpp
+++ b/server-plugin/Code/plugin.cpp
@@ -34,6 +34,7 @@
 #include "Systems/Blockers/BadUserCmdBlocker.h"
 #include "Systems/Blockers/WallhackBlocker.h"
 #include "Systems/Blockers/RadarHackBlocker.h"
+#include "Systems/Blockers/BhopBlocker.h"
 #include "Systems/BanRequest.h"
 #include "Systems/ConfigManager.h"
 #include "Systems/Logger.h"
@@ -83,6 +84,7 @@ void CNoCheatZPlugin::CreateSingletons ()
 	AntiFlashbangBlocker::CreateInstance ();
 	AntiSmokeBlocker::CreateInstance ();
 	BadUserCmdBlocker::CreateInstance ();
+	BhopBlocker::CreateInstance ();
 	WallhackBlocker::CreateInstance ();
 	ConCommandTester::CreateInstance ();
 	ConVarTester::CreateInstance ();
@@ -113,6 +115,7 @@ void CNoCheatZPlugin::DestroySingletons ()
 	ConVarTester::DestroyInstance ();
 	ConCommandTester::DestroyInstance ();
 	WallhackBlocker::DestroyInstance ();
+	BhopBlocker::DestroyInstance ();
 	BadUserCmdBlocker::DestroyInstance ();
 	AntiSmokeBlocker::DestroyInstance ();
 	AntiFlashbangBlocker::DestroyInstance ();
@@ -513,6 +516,7 @@ SourceSdk::PLUGIN_RESULT CNoCheatZPlugin::ClientConnect ( bool *bAllowConnect, S
 	WallhackBlocker::GetInstance ()->ResetPlayerDataStruct ( player );
 	SpamChangeNameTester::GetInstance ()->ResetPlayerDataStruct ( player );
 	RadarHackBlocker::GetInstance ()->ResetPlayerDataStruct ( player );
+	BhopBlocker::GetInstance ()->ResetPlayerDataStruct ( player );
 
 	return SourceSdk::PLUGIN_CONTINUE;
 }

--- a/server-plugin/nocheatz.vcxproj
+++ b/server-plugin/nocheatz.vcxproj
@@ -386,6 +386,7 @@ copy "$(TargetPath)" ..\..\..\game\bin\"$(TargetName)".pdb
     <ClCompile Include="Code\Misc\HeapMemoryManager.cpp" />
     <ClCompile Include="Code\Misc\MathCache.cpp" />
     <ClCompile Include="Code\Systems\AutoTVRecord.cpp" />
+    <ClCompile Include="Code\Systems\Blockers\BhopBlocker.cpp" />
     <ClCompile Include="Code\Systems\Blockers\RadarHackBlocker.cpp" />
     <ClCompile Include="Code\Systems\ConfigManager.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</ExcludedFromBuild>
@@ -452,6 +453,7 @@ copy "$(TargetPath)" ..\..\..\game\bin\"$(TargetName)".pdb
     <ClInclude Include="Code\Misc\temp_Throwback.h" />
     <ClInclude Include="Code\Players\ProcessFilter.h" />
     <ClInclude Include="Code\Systems\AutoTVRecord.h" />
+    <ClInclude Include="Code\Systems\Blockers\BhopBlocker.h" />
     <ClInclude Include="Code\Systems\Blockers\RadarHackBlocker.h" />
     <ClInclude Include="Code\Systems\ConfigManager.h" />
     <ClInclude Include="Code\Systems\i18nManager.h" />

--- a/server-plugin/nocheatz.vcxproj.filters
+++ b/server-plugin/nocheatz.vcxproj.filters
@@ -243,6 +243,9 @@
     <ClCompile Include="Code\Systems\Testers\AutoAttackTester.cpp">
       <Filter>Code\Systems\Testers</Filter>
     </ClCompile>
+    <ClCompile Include="Code\Systems\Blockers\BhopBlocker.cpp">
+      <Filter>Code\Systems\Blockers</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Code\plugin.h">
@@ -547,6 +550,9 @@
     </ClInclude>
     <ClInclude Include="Code\Misc\temp_Throwback.h">
       <Filter>Code\Misc</Filter>
+    </ClInclude>
+    <ClInclude Include="Code\Systems\Blockers\BhopBlocker.h">
+      <Filter>Code\Systems\Blockers</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
related #77 

The BhopBlocker system will prevents players to rejump after landing during a short amount of time.

This update also takes into account the new convars from the latest cSGO update at the time ( sv_enablebunnyhopping and sv_autobunnyhopping ) which will disable the JumpTester and the BhopBlocker systems if any of those ConVars are true.

related #80 
The AutoAttackTester has been tweaked to prevent false detection.

related #79 
FIxed the same bug introduced by logging player_disconnect

closes #84 
No false detection found durig heavy integration tests.

closes #72 
Even if the WallhackBlocker doesn't works perfectly, no completly-filtered players has been encountered during integration tests.